### PR TITLE
게시판 API 만들기 - Data REST 적용 및 테스트 정의 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 }
 
 tasks.named('test') {

--- a/src/main/java/copro/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/copro/projectboard/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package copro.projectboard.repository;
 
 import copro.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/copro/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/copro/projectboard/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package copro.projectboard.repository;
 
 import copro.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/test/java/copro/projectboard/repository/controller/DataRestTest.java
+++ b/src/test/java/copro/projectboard/repository/controller/DataRestTest.java
@@ -1,0 +1,95 @@
+package copro.projectboard.repository.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import javax.transaction.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("Data REST - API 테스트")
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc){
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    public void 게시글_리스트조회() throws Exception {
+        //given
+
+        //when & then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+
+
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    public void 게시글_단건조회() throws Exception {
+        //given
+
+        //when & then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+        }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    public void 게시글_댓글리스트조회() throws Exception {
+        //given
+
+        //when & then
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+        }
+
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    public void 댓글리스트조회() throws Exception {
+        //given
+
+        //when & then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    public void 댓글단건조회() throws Exception {
+        //given
+
+        //when & then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+
+    }
+}
+


### PR DESCRIPTION
게시글, 댓글 데이터는 가편하게 Spring Data REST로 서비스하고, 해당 API들의 존재 여부만 체크하게끔 통합테스트 작성